### PR TITLE
fix BreadcrumbSeparator vertical alignment

### DIFF
--- a/components/ui/breadcrumb/BreadcrumbSeparator.vue
+++ b/components/ui/breadcrumb/BreadcrumbSeparator.vue
@@ -12,7 +12,7 @@ const props = defineProps<{
   <li
     role="presentation"
     aria-hidden="true"
-    :class="cn('[&>svg]:size-3.5', props.class)"
+    :class="cn('inline-flex items-center [&>svg]:size-3.5', props.class)"
   >
     <slot>
       <ChevronRight />


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/10f5dbdd-aaa9-49a5-a882-f1c37c8da7df)


Before:

![image](https://github.com/user-attachments/assets/e7135cf8-3671-4637-872c-99b643b83e7c)

After:

![image](https://github.com/user-attachments/assets/c1569bb5-5c50-46a7-9c5e-7c2b90a37049)
