### PR TITLE
Fix incorrect Breadcrumb Link

### DIFF
--- a/components/layout/Header.vue
+++ b/components/layout/Header.vue
@@ -5,7 +5,9 @@ function setLinks() {
   if (route.fullPath === '/') {
     return [{ title: 'Home', href: '/' }]
   }
-  return route.fullPath.split('/').map((item, index) => {
+  const segments = route.fullPath.split('/').filter(item => item !== '')
+
+  return segments.map((item, index) => {
     const str = item.replace(/-/g, ' ')
     const title = str
       .split(' ')
@@ -13,8 +15,8 @@ function setLinks() {
       .join(' ')
 
     return {
-      title: index > 0 ? title : 'Home',
-      href: index > 0 ? `/${item}` : '/',
+      title: index === 0 ? 'Home' : title,
+      href: `/${segments.slice(0, index + 1).join('/')}`,
     }
   })
 }


### PR DESCRIPTION
Hey there! 👋

I noticed that when the breadcrumb path is long, the generated links were incorrect. Instead of constructing the full path step by step, each breadcrumb was linking to separate segments (e.g., /latihan, /api, /external instead of /latihan/api/external).

I’ve fixed this by ensuring that each breadcrumb correctly builds upon the previous path, so it now works for longer URLs. 🎯

Hope this helps! Let me know if there’s anything I should adjust. 😊

Cheers! 🚀

**before**
![before fix](https://github.com/user-attachments/assets/f1488a18-41ff-473a-89a0-2a1e3ff618f1)
![console warn no location](https://github.com/user-attachments/assets/d16a745a-cf0e-46bf-a771-d26583470535)

**after**
![after fix](https://github.com/user-attachments/assets/013b2dbb-6c61-44ca-b437-4b27c3e23024)
