### PR TITLE
fix: incorrect breadcrumb link

### DIFF
--- a/components/layout/Header.vue
+++ b/components/layout/Header.vue
@@ -5,7 +5,10 @@ function setLinks() {
   if (route.fullPath === '/') {
     return [{ title: 'Home', href: '/' }]
   }
-  return route.fullPath.split('/').map((item, index) => {
+
+  const segments = route.fullPath.split('/').filter(item => item !== '')
+
+  const breadcrumbs = segments.map((item, index) => {
     const str = item.replace(/-/g, ' ')
     const title = str
       .split(' ')
@@ -13,10 +16,12 @@ function setLinks() {
       .join(' ')
 
     return {
-      title: index > 0 ? title : 'Home',
-      href: index > 0 ? `/${item}` : '/',
+      title,
+      href: `/${segments.slice(0, index + 1).join('/')}`,
     }
   })
+
+  return [{ title: 'Home', href: '/' }, ...breadcrumbs]
 }
 
 const links = ref<{


### PR DESCRIPTION
Hey there! 👋

I noticed that **when the breadcrumb path is long**, the generated links were incorrect. Instead of constructing the full path step by step, each breadcrumb was linking to separate segments (e.g., /latihan, /api, /external instead of /latihan/api/external).

![before fix](https://github.com/user-attachments/assets/5ac73ceb-af5b-454f-9b44-171fcb7ec6cc)
![console warn no location](https://github.com/user-attachments/assets/549f95a6-605a-43bd-9a6b-df7fbb57231a)

I’ve fixed this by ensuring that each breadcrumb correctly builds upon the previous path, so it now works for longer URLs. 🎯

![after fix](https://github.com/user-attachments/assets/6685acf6-3f92-4199-b795-1511983e7687)

Hope this helps! Let me know if there’s anything I should adjust. 😊

Cheers! 🚀