### PR TITLE
Fix social login buttons alignment on Register page

### DIFF
--- a/app/components/auth/SignUp.vue
+++ b/app/components/auth/SignUp.vue
@@ -65,7 +65,7 @@ async function onSubmit(event: Event) {
       </div>
     </form>
     <Separator label="Or continue with" />
-    <div class="flex items-center gap-4">
+    <div class="flex items-center gap-4 flex-col">
       <Button variant="outline" class="w-full gap-2">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="size-4">
           <path


### PR DESCRIPTION
## Description
The "Sign in with Apple" and "Google" buttons were not stacking correctly (misaligned/overlapping).

This PR adds the `flex-col` class to the button container to ensure they stack vertically and look consistent.

## Changes
- Added `flex-col` to the social login buttons container.

## Screenshots
| Before | After |
| :---: | :---: |
| <img width="1611" height="960" alt="image" src="https://github.com/user-attachments/assets/1c1efe09-76a1-465a-b63b-42117733d85c" /> | <img width="1677" height="960" alt="image" src="https://github.com/user-attachments/assets/6fd0f108-f9ca-4834-b0f5-ed897ea7ca08" /> |